### PR TITLE
Fixes Issue #8: Add GitHub template for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+Please include a general summary of the change and/or which issue it fixed. 
+
+Fixes #(issue number)
+
+## Type of change 
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Have you tested your changes
+Please give a brief description of how you tested your changes to make sure they work.
+
+## Screenshot (if applicable)
+<!-- Screenshot goes here -->
+
+## Checklist:
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings


### PR DESCRIPTION
## Description
Added the Pull Request template to the repository under `.github` directory as per GitHub's guidelines. 

Fixes #8 